### PR TITLE
pin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 # rvr_circuitpython
+
 This is my collection of code that I've used to run the RVR using CircuitPython.
 
 My notes learning to use the Sphero RVR API for the Drive to Position functionality are linked here: [Link](https://drive.google.com/file/d/1oYMbidrGnvpz_ruhsh2HalU-BsVFMmpa/view?usp=sharing)
+
+## Pin connection definition Microcontroller - RVR
+
+We use the following standard pins to communicate with the Sphero RVR:
+
+|                    | blackpill | rp2040 | lilygo ESP32-S2 | Metro M4 express |
+|--------------------|:---------:|:------:|:---------------:|:----------------:|
+| UART TX            |     A2    |   GP4  |       IO1       |        D1        |
+| UART RX            |     A3    |   GP5  |       IO2       |        D0        |
+| Ultrasonic trigger |     B1    |  GP10  |       IO5       |        D11       |
+| Ultrasonic echo    |     B0    |  GP11  |       IO4       |        D10       |


### PR DESCRIPTION
Four examples with M4 Metro express, blackpill F411CEU, Raspberry Pi Pico and ESP32-S2 T-Display take over controll of the Sphero RVR. Only the definition for the 4 connected pins has to be adjusted.